### PR TITLE
fixed shebang re: python3 and updated broken export PS1 in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple rainbow text effect suitable for 256-bit color ANSI terminal; particularl
 Simple example usage (possibly in ~/.bashrc):
 
 ```
-export PS1=$(rainbowfy $USER@$(hostname))":\w >\ [\033[0;00m\] "
+export PS1=$(python3 rainbowfy $USER@$(hostname))":\w >\ [\033[0;00m\] "
 ```
  Explanation of how it works:
  

--- a/rainbowfy
+++ b/rainbowfy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 import math


### PR DESCRIPTION
I found rainbowfy only works in python3.

The original use case in readme was 

```
export PS1=$(rainbowfy $USER@$(hostname))":\w >\ [\033[0;00m\] "
```

This only works if $(pwd) is in the PATH.  Explicitly calling python3 fixes this.
